### PR TITLE
add new example_finished hook (rspec 3.4.0)

### DIFF
--- a/lib/parallel_rspec/client.rb
+++ b/lib/parallel_rspec/client.rb
@@ -26,6 +26,10 @@ module ParallelRSpec
       channel_to_server.write([:example_failed, serialize_example(example)])
     end
 
+    def example_finished(example)
+      channel_to_server.write([:example_finished, serialize_example(example)])
+    end
+
     def example_pending(example)
       channel_to_server.write([:example_pending, serialize_example(example)])
     end

--- a/lib/parallel_rspec/server.rb
+++ b/lib/parallel_rspec/server.rb
@@ -22,6 +22,10 @@ module ParallelRSpec
       reporter.example_failed(example)
     end
 
+    def example_finished(example, channel_to_client)
+      reporter.example_finished(example)
+    end
+
     def example_pending(example, channel_to_client)
       reporter.example_pending(example)
     end


### PR DESCRIPTION
I'm using rspec 3.4.0 / rspec-core 3.4.1 and was getting the following errors on running tests:

```/Users/charles/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/example.rb:447:in `finish': undefined method `example_finished' for #<ParallelRSpec::Client:0x007f8c226190d0> (NoMethodError)```

The [example_finished](http://www.rubydoc.info/gems/rspec-core/3.4.0/RSpec/Core/Formatters/Protocol#example_finished-instance_method) hook was added in [RSpec 3.4.0] (http://rspec.info/blog/2015/11/rspec-3-4-has-been-released/), this PR adds a corresponding method to the client and server so it works nicely now. 

Thanks! ;)