### PR TITLE
allow use with non-db/ActiveRecord projects

### DIFF
--- a/lib/parallel_rspec/workers.rb
+++ b/lib/parallel_rspec/workers.rb
@@ -55,9 +55,11 @@ module ParallelRSpec
     end
 
     def establish_test_database_connection(worker)
-      ENV['TEST_ENV_NUMBER'] = worker.to_s
-      ActiveRecord::Base.configurations['test']['database'] << worker.to_s unless worker == 1
-      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
+      if defined?(ActiveRecord)
+        ENV['TEST_ENV_NUMBER'] = worker.to_s
+        ActiveRecord::Base.configurations['test']['database'] << worker.to_s unless worker == 1
+        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
+      end
     end
 
     def verify_children(child_pids)

--- a/lib/parallel_rspec/workers.rb
+++ b/lib/parallel_rspec/workers.rb
@@ -55,8 +55,8 @@ module ParallelRSpec
     end
 
     def establish_test_database_connection(worker)
+      ENV['TEST_ENV_NUMBER'] = worker.to_s
       if defined?(ActiveRecord)
-        ENV['TEST_ENV_NUMBER'] = worker.to_s
         ActiveRecord::Base.configurations['test']['database'] << worker.to_s unless worker == 1
         ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations['test'])
       end


### PR DESCRIPTION
This may or may not be useful to others, raising a PR for consideration just in case.

I'm testing an application which has no database, no ActiveRecord, and therefore no `config/database.yml`.  This seemed like the quickest way to prevent the errors I was getting and use the rspec parallelisation without a db.