### PR TITLE
Update the rspec persistence file after concluding a run

### DIFF
--- a/lib/parallel_rspec/runner.rb
+++ b/lib/parallel_rspec/runner.rb
@@ -63,6 +63,9 @@ module ParallelRSpec
           with_context_hooks, without_context_hooks = example_groups.partition(&:any_context_hooks?)
           success = run_in_parallel(without_context_hooks, reporter)
           success &&= with_context_hooks.map { |g| g.run(reporter) }.all?
+
+          persist_example_statuses
+
           success ? 0 : @configuration.failure_exit_code
         end
       end


### PR DESCRIPTION
The rspec persistence file (if configured) tracks the status of the last
run of a given set of specs, and allows you to use features like
"--only-failures". If prspec updates this file then repeated runs of
prspec with --only-failures can be useful for gradually fixing a large
chunk of failures without re-running an entire test suite.
