### PR TITLE
Fix crash when used with rspec profile formatter

### DIFF
--- a/lib/parallel_rspec/client.rb
+++ b/lib/parallel_rspec/client.rb
@@ -35,14 +35,6 @@ module ParallelRSpec
       @channel_to_server = channel_to_server
     end
 
-    def example_group_started(group)
-      # not implemented yet - would need the same extraction/simplification for serialization as Example below
-    end
-
-    def example_group_finished(group)
-      # ditto
-    end
-
     def example_started(example)
       channel_to_server.write([:example_started, example.id, updates_from(example)])
     end


### PR DESCRIPTION
When using parallel_rspec in combination with rspec's profile formatter, there is an exception at the very end of the test run, when the slowest example groups are supposed to be printed.
The reason is, that parallel_rspec skips calling `run` on the ExampleGroups and therefore the `example_group_started` and `example_group_finished` notifications are never sent.

This commit works around that by keeping track of started and finished (top-level) example groups in the server and sending these notifications to the reporter.

Fixes #14 