### PR TITLE
Always run the example groups with context hooks

### DIFF
--- a/lib/parallel_rspec/runner.rb
+++ b/lib/parallel_rspec/runner.rb
@@ -61,12 +61,12 @@ module ParallelRSpec
       @configuration.reporter.report(@world.example_count(example_groups)) do |reporter|
         @configuration.with_suite_hooks do
           with_context_hooks, without_context_hooks = example_groups.partition(&:any_context_hooks?)
-          success = run_in_parallel(without_context_hooks, reporter)
-          success &&= with_context_hooks.map { |g| g.run(reporter) }.all?
+          parallel_success = run_in_parallel(without_context_hooks, reporter)
+          sequential_success = with_context_hooks.map { |g| g.run(reporter) }.all?
 
           persist_example_statuses
 
-          success ? 0 : @configuration.failure_exit_code
+          (parallel_success && sequential_success) ? 0 : @configuration.failure_exit_code
         end
       end
     end


### PR DESCRIPTION
Previously we used `&&=` which does short circuit evaluation, meaning if there's a failure in any of the specs run in parallel, we won't run the specs that have to be run in sequence. This can be surprising, especially if we've not specified that we want to `--fail-fast`. Change to more explicitly always run both sets of example groups and use `&&` at the end to combine the outcomes.